### PR TITLE
Update scikit-image requirement to 0.14.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 filterpy==1.4.5
-scikit-image==0.14.0
+scikit-image==0.14.2
 lap==0.4.0


### PR DESCRIPTION
I forked this repository and ran it as is, and encountered an error when trying to run `sort.py`. I found this issue [here](https://github.com/numpy/numpy/issues/12744), which suggests upgrading `scikit-image` to `0.14.2`. The upgrade fixed it. 