### PR TITLE
Fix so results are returned in same order as input

### DIFF
--- a/sort.py
+++ b/sort.py
@@ -240,7 +240,7 @@ class Sort(object):
         trk = KalmanBoxTracker(dets[i,:])
         self.trackers.append(trk)
     i = len(self.trackers)
-    for trk in reversed(self.trackers):
+    for trk in self.trackers:
         d = trk.get_state()[0]
         if (trk.time_since_update < 1) and (trk.hit_streak >= self.min_hits or self.frame_count <= self.min_hits):
           ret.append(np.concatenate((d,[trk.id+1])).reshape(1,-1)) # +1 as MOT benchmark requires positive


### PR DESCRIPTION
Currently the bounding box array is reversed before it is returned.

I have no idea why this is, it doesn't seem to be used anywhere or change the results at all.

By returning the bounding boxes in the same order as the input, it makes it easier for the user to assign the tracker IDs to their original input objects using the same indices for the input and output. 