### PR TITLE
Fix error on pip install -r requirements.txt by updating dependencies versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 filterpy==1.4.5
-scikit-image==0.17.2
-lap==0.4.0
+scikit-image==0.25.2
+lap==0.5.12


### PR DESCRIPTION
## Spec

Python version: 3.10.12 

## Steps to reproduce

1. Create fresh venv
```bash
python -m venv .venv
source .venv/bin/activate
```

2. Attempt installing requirements
```bash
(.venv) quakumei@liuliuliu:~/Desktop/Syncthing/StudiesAndBooks/sort$ pip install -r requirements.txt 
Collecting filterpy==1.4.5
  Downloading filterpy-1.4.5.zip (177 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 178.0/178.0 KB 788.3 kB/s eta 0:00:00
  Preparing metadata (setup.py) ... done
Collecting scikit-image==0.17.2
  Downloading scikit-image-0.17.2.tar.gz (29.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 29.8/29.8 MB 272.4 kB/s eta 0:00:00
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-qyf03opt/scikit-image_3093bbefcf6a43179405c676a4772f43/setup.py", line 234, in <module>
          'build_ext': openmp_build_ext(),
        File "/tmp/pip-install-qyf03opt/scikit-image_3093bbefcf6a43179405c676a4772f43/setup.py", line 58, in openmp_build_ext
          from numpy.distutils.command.build_ext import build_ext
      ModuleNotFoundError: No module named 'numpy'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

## What I tried

### Installed numpy beforehand - results in error

```bash
(.venv) quakumei@liuliuliu:~/Desktop/Syncthing/StudiesAndBooks/sort$ pip install numpy && pip install -r requirements.txt
  Running setup.py install for lap ... error
  error: subprocess-exited-with-error
  
  × Running setup.py install for lap did not run successfully.
  │ exit code: 1
  ╰─> [532 lines of output]
      Partial import of lap during the build process.
      /tmp/pip-install-lb2acrqa/lap_236af5b276c04712a73c805b940104be/setup.py:223: DeprecationWarning:
      
        `numpy.distutils` is deprecated since NumPy 1.23.0, as a result
        of the deprecation of `distutils` itself. It will be removed for
        Python >= 3.12. For older Python versions it will remain present.
        It is recommended to use `setuptools < 60.0` for those Python versions.
        For more details, see:
          https://numpy.org/devdocs/reference/distutils_status_migration.html
      
      
        from numpy.distutils.core import setup
      Generating cython files
      running install
      /home/quakumei/Desktop/Syncthing/StudiesAndBooks/sort/.venv/lib/python3.10/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
        warnings.warn(
      running build
      running config_cc
      INFO: unifying config_cc

#
# ... big trace here ...
#

      INFO: CCompilerOpt.cache_flush[864] : write cache to path -> /tmp/pip-install-lb2acrqa/lap_236af5b276c04712a73c805b940104be/build/temp.linux-x86_64-3.10/ccompiler_opt_cache_ext.py
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: legacy-install-failure

× Encountered error while trying to install package.
╰─> lap
```

Setting a restriction `"numpy<2"` caused analogous error, but for scikit-image. I suppose, that is because the scikit-image's version is old.

### (This worked) Installing up-to-date versions of lap, filterpy and scikit-image.

```bash
(.venv) quakumei@liuliuliu:~/Desktop/Syncthing/StudiesAndBooks/sort$ pip install filterpy lap scikit-image
# ... install logs ...
Installing collected packages: six, pyparsing, pillow, packaging, numpy, networkx, kiwisolver, fonttools, cycler, tifffile, scipy, python-dateutil, lazy-loader, lap, imageio, contourpy, scikit-image, matplotlib, filterpy
Successfully installed contourpy-1.3.2 cycler-0.12.1 filterpy-1.4.5 fonttools-4.58.4 imageio-2.37.0 kiwisolver-1.4.8 lap-0.5.12 lazy-loader-0.4 matplotlib-3.10.3 networkx-3.4.2 numpy-2.2.6 packaging-25.0 pillow-11.2.1 pyparsing-3.2.3 python-dateutil-2.9.0.post0 scikit-image-0.25.2 scipy-1.15.3 six-1.17.0 tifffile-2025.5.10

(.venv) quakumei@liuliuliu:~/Desktop/Syncthing/StudiesAndBooks/sort$ pip freeze | grep "filterpy"
filterpy==1.4.5
(.venv) quakumei@liuliuliu:~/Desktop/Syncthing/StudiesAndBooks/sort$ pip freeze | grep "lap"
lap==0.5.12
(.venv) quakumei@liuliuliu:~/Desktop/Syncthing/StudiesAndBooks/sort$ pip freeze | grep "scikit-image"
scikit-image==0.25.2
```

Now if we change requirements.txt to
```requirements.txt
filterpy==1.4.5
lap==0.5.12
scikit-image==0.25.2
```

Install from clean env is good.
```bash
(.venv) quakumei@liuliuliu:~/Desktop/Syncthing/StudiesAndBooks/sort$ pip install -r requirements.txt 
Collecting filterpy==1.4.5
  Using cached filterpy-1.4.5-py3-none-any.whl
Collecting lap==0.5.12
  Using cached lap-0.5.12-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.7 MB)
Collecting scikit-image==0.25.2
  Using cached scikit_image-0.25.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (14.8 MB)
Collecting matplotlib
  Using cached matplotlib-3.10.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (8.6 MB)
Collecting scipy
  Using cached scipy-1.15.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (37.7 MB)
Collecting numpy
  Using cached numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (16.8 MB)
Collecting imageio!=2.35.0,>=2.33
  Using cached imageio-2.37.0-py3-none-any.whl (315 kB)
Collecting packaging>=21
  Using cached packaging-25.0-py3-none-any.whl (66 kB)
Collecting pillow>=10.1
  Using cached pillow-11.2.1-cp310-cp310-manylinux_2_28_x86_64.whl (4.6 MB)
Collecting tifffile>=2022.8.12
  Using cached tifffile-2025.5.10-py3-none-any.whl (226 kB)
Collecting networkx>=3.0
  Using cached networkx-3.4.2-py3-none-any.whl (1.7 MB)
Collecting lazy-loader>=0.4
  Using cached lazy_loader-0.4-py3-none-any.whl (12 kB)
Collecting fonttools>=4.22.0
  Using cached fonttools-4.58.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (4.8 MB)
Collecting pyparsing>=2.3.1
  Using cached pyparsing-3.2.3-py3-none-any.whl (111 kB)
Collecting cycler>=0.10
  Using cached cycler-0.12.1-py3-none-any.whl (8.3 kB)
Collecting python-dateutil>=2.7
  Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl (229 kB)
Collecting kiwisolver>=1.3.1
  Using cached kiwisolver-1.4.8-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (1.6 MB)
Collecting contourpy>=1.0.1
  Using cached contourpy-1.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (325 kB)
Collecting six>=1.5
  Using cached six-1.17.0-py2.py3-none-any.whl (11 kB)
Installing collected packages: six, pyparsing, pillow, packaging, numpy, networkx, kiwisolver, fonttools, cycler, tifffile, scipy, python-dateutil, lazy-loader, lap, imageio, contourpy, scikit-image, matplotlib, filterpy
Successfully installed contourpy-1.3.2 cycler-0.12.1 filterpy-1.4.5 fonttools-4.58.4 imageio-2.37.0 kiwisolver-1.4.8 lap-0.5.12 lazy-loader-0.4 matplotlib-3.10.3 networkx-3.4.2 numpy-2.2.6 packaging-25.0 pillow-11.2.1 pyparsing-3.2.3 python-dateutil-2.9.0.post0 scikit-image-0.25.2 scipy-1.15.3 six-1.17.0 tifffile-2025.5.10
```

## Test that it didn't break anything

```bash
(.venv) quakumei@liuliuliu:~/Desktop/Syncthing/StudiesAndBooks/sort$ python sort.py
Processing ADL-Rundle-8.
Processing ETH-Pedcross2.
Processing TUD-Stadtmitte.
Processing ETH-Sunnyday.
Processing PETS09-S2L1.
Processing KITTI-13.
Processing TUD-Campus.
Processing ETH-Bahnhof.
Processing Venice-2.
Processing KITTI-17.
Processing ADL-Rundle-6.
Total Tracking took: 2.294 seconds for 5500 frames or 2397.7 FPS
```